### PR TITLE
Tentative RationalResources compatibility

### DIFF
--- a/OPX-NeidonPlus/Patches/RationalResources.cfg
+++ b/OPX-NeidonPlus/Patches/RationalResources.cfg
@@ -1,0 +1,61 @@
++PLANETARY_RESOURCE:HAS[#Tag[SrfRockIce]]:NEEDS[OPX-NeidonPlus,RationalResources]
+{
+	@PlanetName = Nito
+	@Tag = Applied
+}
++PLANETARY_RESOURCE:HAS[#Tag[SrfRockIce]]:NEEDS[OPX-NeidonPlus,RationalResources]
+{
+	@PlanetName = Tito
+	@Tag = Applied
+}
++PLANETARY_RESOURCE:HAS[#Tag[SrfRockMetal]]:NEEDS[OPX-NeidonPlus,RationalResources]
+{
+	@PlanetName = Hargaladh
+	@Tag = Applied
+}
++PLANETARY_RESOURCE:HAS[#Tag[SrfRock]]:NEEDS[OPX-NeidonPlus,RationalResources]
+{
+	@PlanetName = Gryspar
+	@Tag = Applied
+}
++PLANETARY_RESOURCE:HAS[#Tag[IceMethane]]:NEEDS[OPX-NeidonPlus,RationalResources]
+{
+	@PlanetName = Chymere
+	@Tag = Applied
+}
++PLANETARY_RESOURCE:HAS[#Tag[ExoIce]]:NEEDS[OPX-NeidonPlus,RationalResources]
+{
+	@PlanetName = Chymere
+	@Tag = Applied
+}
++PLANETARY_RESOURCE:HAS[#Tag[RockIce]]:NEEDS[OPX-NeidonPlus,RationalResources]
+{
+	@PlanetName = Nyla
+	@Tag = Applied
+}
++PLANETARY_RESOURCE:HAS[#Tag[IceWater]]:NEEDS[OPX-NeidonPlus,RationalResources]
+{
+	@PlanetName = Psei
+	@Tag = Applied
+}
+
+@EXPERIMENT_DEFINITION:HAS[#id[RRplanetClass]]:NEEDS[OPX-NeidonPlus,RationalResources]
+{
+	@RESULTS
+	{
+		NitoInSpaceHigh = #$@RR_SCIDICT/RR_Class_SrfRockIceHigh$
+		NitoInSpaceLow = #$@RR_SCIDICT/RR_Class_SrfRockIceLow$
+		TitoInSpaceHigh = #$@RR_SCIDICT/RR_Class_SrfRockIceHigh$
+		TitoInSpaceLow = #$@RR_SCIDICT/RR_Class_SrfRockIceLow$
+		HargaladhInSpaceHigh = #$@RR_SCIDICT/RR_Class_SrfRockMetalHigh$
+		HargaladhInSpaceLow = #$@RR_SCIDICT/RR_Class_SrfRockMetalLow$
+		GrysparInSpaceHigh = #$@RR_SCIDICT/RR_Class_SrfRockHigh$
+		GrysparInSpaceLow = #$@RR_SCIDICT/RR_Class_SrfRockLow$
+		ChymereInSpaceHigh = #$@RR_SCIDICT/RR_Class_SrfIceMethaneHigh$
+		ChymereInSpaceLow = #$@RR_SCIDICT/RR_Class_SrfIceMethaneLow$ $@RR_SCIDICT/RR_Class_ExoIce$
+		NylaInSpaceHigh = #$@RR_SCIDICT/RR_Class_SrfRockIceHigh$
+		NylaInSpaceLow = #$@RR_SCIDICT/RR_Class_SrfRockIceLow$
+		PseiInSpaceHigh = #$@RR_SCIDICT/RR_Class_SrfIceWaterHigh$
+		PseiInSpaceLow = #$@RR_SCIDICT/RR_Class_SrfIceWaterLow$
+	}
+}


### PR DESCRIPTION
Saw your mod and it looked pretty cool, so I was compelled to write a compatibility patch for it. Hopefully these make sense, but it's fine if they don't and are just motivation to figure out the correct configs — "if you want the right answer, offer the wrong one", and so on.

(Densities are assuming 10x scale.)

**Nito: RockIce.** Mixed coloration but diamond-shaped material in surface sample implies perhaps both rock and ice. Density ~1.7 g/cm^3, rubble-pile or mixed icy composition? Let's go with the latter.
**Tito: RockIce.** Darker color - clearly some rock/dust in composition. Density ~1.6 g/cm^3, but also surface sample's "hard, semi-tough surface" - maybe that's compacted ice?
**Hargaladh: RockMetal.** Density ~10 g/cm^3, and surface sample implies metallic composition.
**Gryspar: Rock.** Dark with density ~3 g/cm^3.
**Chymere: IceMethane, ExoIce.** Density ~4 g/cm^3 but bright and called "more like Mimas" in the forum thread, so icy surface it is. Notably tholin-bearing bodies in MPE (Soden, Mracksis) get IceMethane. "A thin exosphere seems to be pooling near the basins"; ExoIce is common for distant bodies and consistent with icy behavior in system.

Thatmo unchanged (IceNitrogen, AtmIceNitrogen). Could use something for the seas, but with density=1.3 I'm not totally sure what that is.
Nissee unchanged (IceWater, ExoIce)

**Nyla: RockIce.** Dark with density ~1.7 g/cm^3.
**Psei: IceWater.** Light with density ~1.5 g/cm^3. Shrug.