### PR TITLE
Fixed my own RR defs

### DIFF
--- a/OPX-NeidonPlus/Patches/OPX-NeidonPlus-RationalResources.cfg
+++ b/OPX-NeidonPlus/Patches/OPX-NeidonPlus-RationalResources.cfg
@@ -18,7 +18,7 @@
 	@PlanetName = Gryspar
 	@Tag = Applied
 }
-+PLANETARY_RESOURCE:HAS[#Tag[IceMethane]]:NEEDS[OPX-NeidonPlus,RationalResources]
++PLANETARY_RESOURCE:HAS[#Tag[SrfIceMethane]]:NEEDS[OPX-NeidonPlus,RationalResources]
 {
 	@PlanetName = Chymere
 	@Tag = Applied
@@ -28,12 +28,12 @@
 	@PlanetName = Chymere
 	@Tag = Applied
 }
-+PLANETARY_RESOURCE:HAS[#Tag[RockIce]]:NEEDS[OPX-NeidonPlus,RationalResources]
++PLANETARY_RESOURCE:HAS[#Tag[SrfRockIce]]:NEEDS[OPX-NeidonPlus,RationalResources]
 {
 	@PlanetName = Nyla
 	@Tag = Applied
 }
-+PLANETARY_RESOURCE:HAS[#Tag[IceWater]]:NEEDS[OPX-NeidonPlus,RationalResources]
++PLANETARY_RESOURCE:HAS[#Tag[SrfIceWater]]:NEEDS[OPX-NeidonPlus,RationalResources]
 {
 	@PlanetName = Psei
 	@Tag = Applied


### PR DESCRIPTION
Whoops, missed some "Srf"s. That was embarrassing.

Also, is there a consensus on the revamped Thatmo's oceans? Density 1.3 is just a little higher than e.g. Ervo-style liquid oxygen at its temperature of 73K, but OPM's RR defs assume Thatmo is mostly nitrogen ice and vapor like Triton itself (but liquid nitrogen isn't nearly dense enough for these oceans).