### PR TITLE
Adding volumetric clouds support.

### DIFF
--- a/OPX-NeidonPlus/Patches/Scatterer/Neidon/atmo.cfg
+++ b/OPX-NeidonPlus/Patches/Scatterer/Neidon/atmo.cfg
@@ -1,4 +1,4 @@
-@Scatterer_atmosphere:AFTER[OPX-NeidonPlus]
+@Scatterer_atmosphere:NEEDS[!OPMVolumetricClouds]:AFTER[OPX-NeidonPlus]
 {
 	!Atmo:HAS[#name[Neidon]]{}
 	Atmo

--- a/OPX-NeidonPlus/Patches/Scatterer/Thatmo/atmo.cfg
+++ b/OPX-NeidonPlus/Patches/Scatterer/Thatmo/atmo.cfg
@@ -1,4 +1,4 @@
-@Scatterer_atmosphere:AFTER[OPX-NeidonPlus]
+@Scatterer_atmosphere:NEEDS[!OPMVolumetricClouds]:AFTER[OPX-NeidonPlus]
 {
 	!Atmo:HAS[#name[Thatmo]]{}
 	Atmo


### PR DESCRIPTION
OPMVolumetricClouds has the configs for all the atmospheric bodies in OPX, but OPX stomps on top of them. This PR just stops these patches from running when OPMVolumetricClouds exists.

Thatmo doesn't have an existing ocean config, so I haven't edited that one.